### PR TITLE
Bump PTB package version to 21.10

### DIFF
--- a/hammett/core/application.py
+++ b/hammett/core/application.py
@@ -1,5 +1,9 @@
 """The module contains the implementation of the high-level application class."""
 
+# ruff: noqa: PLR2004
+
+import logging
+import sys
 from typing import TYPE_CHECKING, Any
 
 from telegram import Update
@@ -37,6 +41,8 @@ if TYPE_CHECKING:
     from hammett.types import Handler, HandlerAlias, NativeStates, State, States
 
 __all__ = ('Application', )
+
+logger = logging.getLogger(__name__)
 
 
 class Application:
@@ -269,6 +275,19 @@ class Application:
     def run(self: 'Self') -> None:
         """Run the application."""
         from hammett.conf import settings
+
+        if ((
+            sys.version_info.minor == 11 and (
+            sys.version_info.micro == 5 or sys.version_info.micro == 6
+        )) or (
+            sys.version_info.minor == 12 and sys.version_info.micro == 0
+        )):
+            logger.warning(
+                "It's recommended to avoid using the following versions of Python: "
+                "3.11.5, 3.11.6, and 3.12.0. The reason for this recommendation is that "
+                "these versions raise a `RuntimeError` upon application termination, "
+                "which may lead to an improper shutdown process.",
+            )
 
         if settings.USE_WEBHOOK:
             self._native_application.run_webhook(

--- a/hammett/core/application.py
+++ b/hammett/core/application.py
@@ -132,7 +132,7 @@ class Application:
             )
         elif handler_type == HandlerType.INPUT_HANDLER:
             handler_object = MessageHandler(
-                possible_handler.filters,  # type: ignore[arg-type]
+                possible_handler.filters,
                 handler,
             )
         elif handler_type == HandlerType.TYPING_HANDLER:

--- a/hammett/core/application.py
+++ b/hammett/core/application.py
@@ -105,7 +105,7 @@ class Application:
         handler: 'HandlerAlias',
         handler_type: 'Any | str | None',
         possible_handler: 'Handler',
-    ) -> CallbackQueryHandler[Any] | MessageHandler[Any]:
+    ) -> CallbackQueryHandler[Any, Any] | MessageHandler[Any, Any]:
         """Return the handler object depending on its type.
 
         Returns
@@ -117,7 +117,7 @@ class Application:
             UnknownHandlerType: If the handler type is unknown.
 
         """
-        handler_object: CallbackQueryHandler[Any] | MessageHandler[Any]
+        handler_object: CallbackQueryHandler[Any, Any] | MessageHandler[Any, Any]
         if handler_type in {HandlerType.BUTTON_HANDLER, ''}:
             handler_object = CallbackQueryHandler(
                 handler,

--- a/hammett/core/persistence.py
+++ b/hammett/core/persistence.py
@@ -70,7 +70,7 @@ class RedisPersistence(BasePersistence[UD, CD, BD]):
 
         """
         super().__init__(
-            store_data=store_data,  # type: ignore[arg-type]
+            store_data=store_data,
             update_interval=update_interval,
         )
 

--- a/hammett/core/renderer.py
+++ b/hammett/core/renderer.py
@@ -205,6 +205,7 @@ class Renderer:
         }
 
         cover = config.cover
+        send: Callable[..., Awaitable[Any]]
         if cover:
             if self._is_url(cover) and config.cache_covers:
                 cover = f'{cover}?{uuid4()}'

--- a/hammett/types.py
+++ b/hammett/types.py
@@ -18,7 +18,7 @@ from hammett.core.screen import Screen
 if TYPE_CHECKING:
     from typing_extensions import Self
 
-CheckUpdateType = tuple[object, ConversationKey, BaseHandler[Update, CCT], object]
+CheckUpdateType = tuple[object, ConversationKey, BaseHandler[Update, CCT, object], object]
 
 
 class Document(TypedDict):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 aiofiles<=23.1.0
-python-telegram-bot[job-queue,webhooks]==20.3
+python-telegram-bot[job-queue,webhooks]==21.10


### PR DESCRIPTION
The proposed changes are necessary to support Python 3.13. Once these changes are accepted, it's recommended to avoid using the following versions of Python: 3.11.5, 3.11.6, and 3.12.0. The reason for this recommendation is that these versions raise `RuntimeError: Event loop is closed` upon application termination, which may lead to an improper shutdown process. You can find more details about the issue at this link: https://github.com/python/cpython/issues/109538.
